### PR TITLE
Add UC4 privacy request approval flow

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import { AuthProvider, useAuth } from './context/auth-context';
 import MainLayout from './components/layout/main-layout';
 import DirectoryPage from './pages/directory-page';
 import EmployerProfilePage from './pages/employer-profile-page';
+import PrivacyRequestsPage from './pages/privacy-requests-page';
 
 //import design files
 import './design/global-theme.css';
@@ -66,7 +67,6 @@ function App() {
               </ProtectedRoute>
             } />
 
-            {/* Merged: Directory routes from the feature branch */}
             <Route path="/directory" element={
               <ProtectedRoute>
                 <MainLayout>
@@ -75,7 +75,6 @@ function App() {
               </ProtectedRoute>
             } />
 
-            {/* Merged: Employer Profile route from the feature branch */}
             <Route path="/directory/:employerId" element={
               <ProtectedRoute>
                 <MainLayout>
@@ -84,7 +83,14 @@ function App() {
               </ProtectedRoute>
             } />
 
-            {/* Merged: Edit Event route from the main branch */}
+            <Route path="/privacy-requests" element={
+              <ProtectedRoute>
+                <MainLayout>
+                  <PrivacyRequestsPage />
+                </MainLayout>
+              </ProtectedRoute>
+            } />
+
             <Route path="/edit-event/:id" element={
               <ProtectedRoute>
                 <MainLayout>

--- a/frontend/src/components/layout/main-layout.jsx
+++ b/frontend/src/components/layout/main-layout.jsx
@@ -126,6 +126,16 @@ const MainLayout = ({ children }) => {
                                 </Button>
                             )}
 
+                            {isAdmin && (
+                                <Button
+                                    color="secondary"
+                                    sx={{ fontWeight: 'bold' }}
+                                    onClick={() => navigate('/privacy-requests')}
+                                >
+                                    בקשות גישה
+                                </Button>
+                            )}
+
                             {isAuthenticated && (
                                 <Button
                                     color="inherit"

--- a/frontend/src/pages/privacy-requests-page.jsx
+++ b/frontend/src/pages/privacy-requests-page.jsx
@@ -1,0 +1,255 @@
+import React, { useEffect, useState } from "react";
+import { useAuth } from "../context/auth-context";
+import { privacyService } from "../services/interfaces/privacy-service";
+
+const formatDate = (timestamp) => {
+  if (!timestamp?.toDate) {
+    return "לא צוין";
+  }
+
+  return timestamp.toDate().toLocaleDateString("he-IL", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+const PrivacyRequestsPage = () => {
+  const { currentUser, userRole } = useAuth();
+
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [actionLoadingId, setActionLoadingId] = useState(null);
+  const [message, setMessage] = useState("");
+
+  const isAdmin = userRole === "admin";
+
+  const loadRequests = async () => {
+    setLoading(true);
+    setMessage("");
+
+    try {
+      const data = await privacyService.getPendingPrivacyRequests();
+      setRequests(data);
+    } catch (error) {
+      console.error("Failed to load privacy requests:", error);
+      setMessage("Failed to load privacy requests.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadRequests();
+  }, []);
+
+  const handleApprove = async (requestId) => {
+    setActionLoadingId(requestId);
+    setMessage("");
+
+    try {
+      await privacyService.approvePrivacyRequest(requestId, currentUser);
+      setMessage("הבקשה אושרה בהצלחה.");
+      await loadRequests();
+    } catch (error) {
+      console.error("Failed to approve privacy request:", error);
+      setMessage("Failed to approve privacy request.");
+    } finally {
+      setActionLoadingId(null);
+    }
+  };
+
+  const handleReject = async (requestId) => {
+    setActionLoadingId(requestId);
+    setMessage("");
+
+    try {
+      await privacyService.rejectPrivacyRequest(requestId, currentUser);
+      setMessage("הבקשה נדחתה בהצלחה.");
+      await loadRequests();
+    } catch (error) {
+      console.error("Failed to reject privacy request:", error);
+      setMessage("Failed to reject privacy request.");
+    } finally {
+      setActionLoadingId(null);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div
+        dir="rtl"
+        style={{
+          padding: "40px",
+          fontFamily: '"Assistant", "Heebo", "Arial", sans-serif',
+        }}
+      >
+        <h1>אין הרשאה</h1>
+        <p>רק מנהלת יכולה לצפות בבקשות גישה לפרטי קשר.</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div
+        dir="rtl"
+        style={{
+          padding: "40px",
+          fontFamily: '"Assistant", "Heebo", "Arial", sans-serif',
+        }}
+      >
+        טוען בקשות גישה...
+      </div>
+    );
+  }
+
+  return (
+    <div
+      dir="rtl"
+      style={{
+        padding: "40px",
+        maxWidth: "1100px",
+        margin: "0 auto",
+        fontFamily: '"Assistant", "Heebo", "Arial", sans-serif',
+      }}
+    >
+      <h1
+        style={{
+          color: "#002b5c",
+          fontSize: "38px",
+          marginBottom: "12px",
+          fontWeight: 700,
+        }}
+      >
+        בקשות גישה לפרטי קשר
+      </h1>
+
+      <p style={{ color: "#555", fontSize: "17px", marginBottom: "28px" }}>
+        כאן ניתן לאשר או לדחות בקשות של רכזים לצפייה בפרטי קשר פרטיים של מעסיקים.
+      </p>
+
+      {message && (
+        <p
+          style={{
+            padding: "12px 16px",
+            borderRadius: "10px",
+            background: "#eef5ff",
+            color: "#003f9e",
+            marginBottom: "20px",
+            fontWeight: 600,
+          }}
+        >
+          {message}
+        </p>
+      )}
+
+      {requests.length === 0 ? (
+        <div
+          style={{
+            padding: "28px",
+            border: "1px solid #dde3ec",
+            borderRadius: "16px",
+            background: "#fff",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.06)",
+          }}
+        >
+          אין בקשות ממתינות כרגע.
+        </div>
+      ) : (
+        <div
+          style={{
+            display: "grid",
+            gap: "16px",
+          }}
+        >
+          {requests.map((request) => (
+            <div
+              key={request.id}
+              style={{
+                padding: "22px",
+                border: "1px solid #dde3ec",
+                borderRadius: "16px",
+                background: "#fff",
+                boxShadow: "0 4px 12px rgba(0,0,0,0.06)",
+              }}
+            >
+              <h2
+                style={{
+                  marginTop: 0,
+                  marginBottom: "14px",
+                  color: "#002b5c",
+                  fontSize: "22px",
+                }}
+              >
+                בקשה מ־{request.requesterEmail}
+              </h2>
+
+              <p style={{ margin: "8px 0" }}>
+                <strong>רכז מבקש:</strong> {request.requesterEmail}
+              </p>
+
+              <p style={{ margin: "8px 0" }}>
+                <strong>מעסיק:</strong> {request.targetEmail}
+              </p>
+
+              <p style={{ margin: "8px 0" }}>
+                <strong>סטטוס:</strong> {request.status}
+              </p>
+
+              <p style={{ margin: "8px 0" }}>
+                <strong>נוצר בתאריך:</strong> {formatDate(request.createdAt)}
+              </p>
+
+              <div
+                style={{
+                  display: "flex",
+                  gap: "12px",
+                  marginTop: "18px",
+                }}
+              >
+                <button
+                  onClick={() => handleApprove(request.id)}
+                  disabled={actionLoadingId === request.id}
+                  style={{
+                    padding: "10px 18px",
+                    border: "none",
+                    borderRadius: "999px",
+                    background: "#0f7b35",
+                    color: "white",
+                    cursor: "pointer",
+                    fontWeight: "bold",
+                    fontFamily: "inherit",
+                  }}
+                >
+                  {actionLoadingId === request.id ? "מאשר..." : "אשר"}
+                </button>
+
+                <button
+                  onClick={() => handleReject(request.id)}
+                  disabled={actionLoadingId === request.id}
+                  style={{
+                    padding: "10px 18px",
+                    border: "none",
+                    borderRadius: "999px",
+                    background: "#b00020",
+                    color: "white",
+                    cursor: "pointer",
+                    fontWeight: "bold",
+                    fontFamily: "inherit",
+                  }}
+                >
+                  {actionLoadingId === request.id ? "דוחה..." : "דחה"}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PrivacyRequestsPage;

--- a/frontend/src/services/interfaces/privacy-service.js
+++ b/frontend/src/services/interfaces/privacy-service.js
@@ -4,6 +4,8 @@ import {
   query,
   where,
   getDocs,
+  doc,
+  updateDoc,
   serverTimestamp,
 } from "firebase/firestore";
 
@@ -122,5 +124,97 @@ export const privacyService = {
     }
 
     return "none";
+  },
+
+  /**
+   * Fetches all pending privacy requests.
+   * This is intended for admin review.
+   *
+   * @returns {Promise<Array>} Pending privacy requests.
+   */
+  async getPendingPrivacyRequests() {
+    const pendingRequestsQuery = query(
+      collection(db, "privacy_requests"),
+      where("status", "==", "pending")
+    );
+
+    const snapshot = await getDocs(pendingRequestsQuery);
+
+    return snapshot.docs.map((docSnap) => {
+      const data = docSnap.data();
+
+      return {
+        id: docSnap.id,
+        requesterEmail: data.requesterEmail || "",
+        targetEmail: data.targetEmail || "",
+        status: data.status || "pending",
+        createdAt: data.createdAt || null,
+        updatedAt: data.updatedAt || null,
+        reviewedAt: data.reviewedAt || null,
+        reviewedBy: data.reviewedBy || null,
+      };
+    });
+  },
+
+  /**
+   * Approves a pending privacy request.
+   *
+   * @param {string} requestId - Firestore document id.
+   * @param {Object} currentUser - Current logged-in admin/employer user.
+   * @returns {Promise<Object>} Result.
+   */
+  async approvePrivacyRequest(requestId, currentUser) {
+    if (!requestId) {
+      throw new Error("Request id is missing.");
+    }
+
+    if (!currentUser?.email) {
+      throw new Error("User must be logged in to approve a request.");
+    }
+
+    const requestRef = doc(db, "privacy_requests", requestId);
+
+    await updateDoc(requestRef, {
+      status: "approved",
+      reviewedAt: serverTimestamp(),
+      reviewedBy: currentUser.email,
+      updatedAt: serverTimestamp(),
+    });
+
+    return {
+      status: "approved",
+      message: "Privacy request approved successfully.",
+    };
+  },
+
+  /**
+   * Rejects a pending privacy request.
+   *
+   * @param {string} requestId - Firestore document id.
+   * @param {Object} currentUser - Current logged-in admin/employer user.
+   * @returns {Promise<Object>} Result.
+   */
+  async rejectPrivacyRequest(requestId, currentUser) {
+    if (!requestId) {
+      throw new Error("Request id is missing.");
+    }
+
+    if (!currentUser?.email) {
+      throw new Error("User must be logged in to reject a request.");
+    }
+
+    const requestRef = doc(db, "privacy_requests", requestId);
+
+    await updateDoc(requestRef, {
+      status: "rejected",
+      reviewedAt: serverTimestamp(),
+      reviewedBy: currentUser.email,
+      updatedAt: serverTimestamp(),
+    });
+
+    return {
+      status: "rejected",
+      message: "Privacy request rejected successfully.",
+    };
   },
 };


### PR DESCRIPTION
## Summary

Completes the UC4 privacy request approval flow.

## Implemented

- Added admin page for pending privacy requests
- Added route for `/privacy-requests`
- Added admin navigation link for access requests
- Added approve/reject actions for privacy requests
- Updated privacy service with pending request fetch and review actions
- Verified that coordinators can see approved/rejected status after admin decision

## Notes

- This flow updates request status in `privacy_requests`.
- Private phone/contact visibility can be connected to `private_info/details` in a follow-up step.