### PR TITLE
Connect private contact details to UC4 approval flow

### DIFF
--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -17,7 +17,8 @@
     "cheerio": "^1.0.0-rc.12",
     "dotenv": "^17.4.2",
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^4.5.0"
+    "firebase-functions": "^4.5.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/node": "^25.7.0",

--- a/backend/functions/scripts/convert-employers-excel-to-json.cjs
+++ b/backend/functions/scripts/convert-employers-excel-to-json.cjs
@@ -1,0 +1,160 @@
+const fs = require("fs");
+const path = require("path");
+const XLSX = require("xlsx");
+
+const excelFilePath = path.join(__dirname, "../data/employers.xlsx");
+const outputJsonPath = path.join(
+  __dirname,
+  "../data/employers_users_import.json"
+);
+
+if (!fs.existsSync(excelFilePath)) {
+  console.error("Missing Excel file:");
+  console.error(excelFilePath);
+  process.exit(1);
+}
+
+const workbook = XLSX.readFile(excelFilePath);
+const firstSheetName = workbook.SheetNames[0];
+const worksheet = workbook.Sheets[firstSheetName];
+
+const rows = XLSX.utils.sheet_to_json(worksheet, {
+  defval: "",
+});
+
+const normalizeValue = (value) => String(value || "").trim();
+const normalizeEmail = (value) => normalizeValue(value).toLowerCase();
+
+const getFirstValue = (row, possibleColumnNames) => {
+  for (const columnName of possibleColumnNames) {
+    if (
+      row[columnName] !== undefined &&
+      normalizeValue(row[columnName]) !== ""
+    ) {
+      return normalizeValue(row[columnName]);
+    }
+  }
+
+  return "";
+};
+
+const employers = [];
+const skippedRows = [];
+const seenEmails = new Set();
+
+rows.forEach((row, index) => {
+  const rowNumber = index + 2;
+
+  const company = getFirstValue(row, [
+    "שם החברה",
+  ]);
+
+  // We intentionally do not use this field as the main company name,
+  // but keep support for it as fallback if the Hebrew company name is missing.
+  const englishCompany = getFirstValue(row, [
+    "שם החברה באנגלית",
+  ]);
+
+  const field = getFirstValue(row, [
+    "תחום העיסוק של החברה",
+  ]);
+
+  const address = getFirstValue(row, [
+    "כתובת\\מיקום החברה",
+    "כתובת/מיקום החברה",
+  ]);
+
+  const fullName = getFirstValue(row, [
+    "שם איש\\ת קשר בחברה",
+    "שם איש/ת קשר בחברה",
+  ]);
+
+  const position = getFirstValue(row, [
+    "תפקיד בחברה",
+  ]);
+
+  const phone = getFirstValue(row, [
+    "מספר טלפון (נייד) של איש\\ת הקשר",
+    "מספר טלפון (נייד) של איש/ת הקשר",
+  ]);
+
+  const email = normalizeEmail(
+    getFirstValue(row, [
+      "כתובת דוא\"ל של איש\\ת הקשר בחברה",
+      "כתובת דוא\"ל של איש/ת הקשר בחברה",
+    ])
+  );
+
+  const neededFields = getFirstValue(row, [
+    "תחומים בהם יש צורך בעובדים",
+  ]);
+
+  const notes = getFirstValue(row, [
+    "הערות",
+  ]);
+
+  if (!email) {
+    skippedRows.push({
+      rowNumber,
+      reason: "Missing email",
+      row,
+    });
+    return;
+  }
+
+  if (seenEmails.has(email)) {
+    skippedRows.push({
+      rowNumber,
+      reason: "Duplicate email",
+      email,
+      row,
+    });
+    return;
+  }
+
+  seenEmails.add(email);
+
+  employers.push({
+    documentId: email,
+    email,
+    role: "employer",
+    isWhitelisted: true,
+
+    privateInfo: {
+      phone,
+      directEmail: email,
+      approved_viewers: [],
+    },
+
+    profile: {
+      company: company || englishCompany,
+      address,
+      field,
+      fullName,
+      position,
+      neededFields,
+      notes,
+    },
+  });
+});
+
+fs.writeFileSync(outputJsonPath, JSON.stringify(employers, null, 2), "utf8");
+
+const skippedReportPath = path.join(
+  __dirname,
+  "../data/employers_users_import_skipped_report.json"
+);
+
+fs.writeFileSync(
+  skippedReportPath,
+  JSON.stringify(skippedRows, null, 2),
+  "utf8"
+);
+
+console.log("Excel conversion finished.");
+console.log(`Sheet used: ${firstSheetName}`);
+console.log(`Total rows read: ${rows.length}`);
+console.log(`Employers exported: ${employers.length}`);
+console.log(`Rows skipped: ${skippedRows.length}`);
+console.log(`Output JSON: ${outputJsonPath}`);
+console.log(`Skipped report: ${skippedReportPath}`);

--- a/backend/functions/scripts/import-employers.cjs
+++ b/backend/functions/scripts/import-employers.cjs
@@ -3,7 +3,10 @@ const fs = require("fs");
 const path = require("path");
 
 const serviceAccountPath = path.join(__dirname, "../../privateKey.json");
-const employersFilePath = path.join(__dirname, "../data/employers_users_import.json");
+const employersFilePath = path.join(
+  __dirname,
+  "../data/employers_users_import.json"
+);
 
 if (!fs.existsSync(serviceAccountPath)) {
   console.error("Missing Firebase private key file:");
@@ -27,10 +30,17 @@ const db = admin.firestore();
 
 const employers = JSON.parse(fs.readFileSync(employersFilePath, "utf8"));
 
+const getFirstValue = (...values) => {
+  return values.find(
+    (value) => value !== undefined && value !== null && String(value).trim() !== ""
+  ) || "";
+};
+
 async function importEmployers() {
   console.log(`Starting import of ${employers.length} employers...`);
 
   let importedCount = 0;
+  let privateInfoCount = 0;
   let skippedCount = 0;
 
   for (const employer of employers) {
@@ -43,6 +53,23 @@ async function importEmployers() {
     }
 
     const normalizedEmail = documentId.toLowerCase().trim();
+
+    const phone = getFirstValue(
+      employer.phone,
+      employer.mobile,
+      employer.privateInfo?.phone,
+      employer.privateInfo?.mobile,
+      employer.profile?.phone,
+      employer.profile?.mobile
+    );
+
+    const directEmail = getFirstValue(
+      employer.directEmail,
+      employer.privateInfo?.directEmail,
+      employer.privateInfo?.email,
+      employer.email,
+      normalizedEmail
+    );
 
     const userDoc = {
       email: normalizedEmail,
@@ -59,10 +86,32 @@ async function importEmployers() {
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
     };
 
+    const privateInfoDoc = {
+      phone,
+      directEmail,
+      approved_viewers: employer.privateInfo?.approved_viewers || [],
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    };
+
     try {
-      await db.collection("users").doc(normalizedEmail).set(userDoc, { merge: true });
+      await db.collection("users").doc(normalizedEmail).set(userDoc, {
+        merge: true,
+      });
+
+      await db
+        .collection("users")
+        .doc(normalizedEmail)
+        .collection("private_info")
+        .doc("details")
+        .set(privateInfoDoc, { merge: true });
+
       console.log(`Imported: ${normalizedEmail}`);
       importedCount++;
+
+      if (phone || directEmail) {
+        privateInfoCount++;
+      }
     } catch (error) {
       console.error(`Failed to import ${normalizedEmail}:`, error.message);
       skippedCount++;
@@ -70,7 +119,8 @@ async function importEmployers() {
   }
 
   console.log("Import finished.");
-  console.log(`Imported: ${importedCount}`);
+  console.log(`Imported users: ${importedCount}`);
+  console.log(`Imported private info docs: ${privateInfoCount}`);
   console.log(`Skipped/failed: ${skippedCount}`);
 }
 

--- a/frontend/src/pages/employer-profile-page.jsx
+++ b/frontend/src/pages/employer-profile-page.jsx
@@ -9,6 +9,7 @@ const EmployerProfilePage = () => {
   const { currentUser, userRole } = useAuth();
 
   const [employer, setEmployer] = useState(null);
+  const [privateDetails, setPrivateDetails] = useState(null);
   const [accessStatus, setAccessStatus] = useState("none");
   const [loading, setLoading] = useState(true);
   const [requestLoading, setRequestLoading] = useState(false);
@@ -29,8 +30,16 @@ const EmployerProfilePage = () => {
     return role || "לא צוין";
   };
 
+  const isVisibleValue = (value) => {
+    return value && value !== "לא צוין" && String(value).trim() !== "";
+  };
+
   useEffect(() => {
     const loadEmployerProfile = async () => {
+      setLoading(true);
+      setMessage("");
+      setPrivateDetails(null);
+
       try {
         const employerData = await directoryService.getDirectoryContactById(
           employerId
@@ -43,13 +52,35 @@ const EmployerProfilePage = () => {
 
         setEmployer(employerData);
 
+        let status = "none";
+
         if (currentUser && !isAdmin) {
-          const status = await privacyService.getContactAccessStatus(
+          status = await privacyService.getContactAccessStatus(
             currentUser,
             employerData
           );
 
           setAccessStatus(status);
+        }
+
+        const shouldLoadPrivateDetails = isAdmin || status === "approved";
+
+        if (currentUser && shouldLoadPrivateDetails) {
+          try {
+            const details = await privacyService.getPrivateContactDetails(
+              currentUser,
+              employerData
+            );
+
+            setPrivateDetails(details);
+          } catch (privateDetailsError) {
+            console.error(
+              "Failed to load private contact details:",
+              privateDetailsError
+            );
+
+            setPrivateDetails(null);
+          }
         }
       } catch (error) {
         console.error("Failed to load employer profile:", error);
@@ -84,7 +115,13 @@ const EmployerProfilePage = () => {
 
   if (loading) {
     return (
-      <div dir="rtl" style={{ padding: "40px" }}>
+      <div
+        dir="rtl"
+        style={{
+          padding: "40px",
+          fontFamily: '"Assistant", "Heebo", "Arial", sans-serif',
+        }}
+      >
         טוען פרופיל מעסיק...
       </div>
     );
@@ -92,7 +129,13 @@ const EmployerProfilePage = () => {
 
   if (!employer) {
     return (
-      <div dir="rtl" style={{ padding: "40px" }}>
+      <div
+        dir="rtl"
+        style={{
+          padding: "40px",
+          fontFamily: '"Assistant", "Heebo", "Arial", sans-serif',
+        }}
+      >
         <h1>פרופיל לא נמצא</h1>
         <p>{message}</p>
       </div>
@@ -106,6 +149,7 @@ const EmployerProfilePage = () => {
         padding: "40px",
         maxWidth: "900px",
         margin: "0 auto",
+        fontFamily: '"Assistant", "Heebo", "Arial", sans-serif',
       }}
     >
       <h1>פרופיל מעסיק</h1>
@@ -120,25 +164,35 @@ const EmployerProfilePage = () => {
           boxShadow: "0 2px 10px rgba(0,0,0,0.06)",
         }}
       >
-        <h2>{employer.organization}</h2>
+        {isVisibleValue(employer.organization) && (
+          <h2>{employer.organization}</h2>
+        )}
 
-        <p>
-          <strong>שם איש קשר:</strong> {employer.name || "לא צוין"}
-        </p>
+        {isVisibleValue(employer.name) && (
+          <p>
+            <strong>שם איש קשר:</strong> {employer.name}
+          </p>
+        )}
 
-        <p>
-          <strong>תפקיד:</strong> {displayRole(employer.role)}
-        </p>
+        {isVisibleValue(employer.role) && (
+          <p>
+            <strong>תפקיד:</strong> {displayRole(employer.role)}
+          </p>
+        )}
 
-        <p>
-          <strong>תחום:</strong> {employer.field || "לא צוין"}
-        </p>
+        {isVisibleValue(employer.field) && (
+          <p>
+            <strong>תחום:</strong> {employer.field}
+          </p>
+        )}
 
-        <p>
-          <strong>כתובת:</strong> {employer.address || "לא צוין"}
-        </p>
+        {isVisibleValue(employer.address) && (
+          <p>
+            <strong>כתובת:</strong> {employer.address}
+          </p>
+        )}
 
-        {employer.notes && (
+        {isVisibleValue(employer.notes) && (
           <p>
             <strong>הערות:</strong> {employer.notes}
           </p>
@@ -150,13 +204,24 @@ const EmployerProfilePage = () => {
 
         {hasApprovedAccess ? (
           <>
-            <p>
-              <strong>אימייל:</strong> {employer.email || "לא צוין"}
-            </p>
+            {isVisibleValue(privateDetails?.directEmail) && (
+              <p>
+                <strong>אימייל:</strong> {privateDetails.directEmail}
+              </p>
+            )}
 
-            <p>
-              <strong>טלפון:</strong> {employer.phone || "לא צוין"}
-            </p>
+            {isVisibleValue(privateDetails?.phone) && (
+              <p>
+                <strong>טלפון:</strong> {privateDetails.phone}
+              </p>
+            )}
+
+            {!isVisibleValue(privateDetails?.directEmail) &&
+              !isVisibleValue(privateDetails?.phone) && (
+                <p style={{ color: "#666" }}>
+                  אין פרטי קשר פרטיים שמורים עבור מעסיק זה.
+                </p>
+              )}
           </>
         ) : (
           <>
@@ -191,7 +256,9 @@ const EmployerProfilePage = () => {
               borderRadius: "999px",
               background: "#1976d2",
               color: "white",
-              cursor: "pointer",
+              cursor: requestLoading ? "not-allowed" : "pointer",
+              opacity: requestLoading ? 0.7 : 1,
+              fontFamily: "inherit",
             }}
           >
             {requestLoading ? "שולח בקשה..." : "Request Access"}

--- a/frontend/src/pages/privacy-requests-page.jsx
+++ b/frontend/src/pages/privacy-requests-page.jsx
@@ -46,11 +46,18 @@ const PrivacyRequestsPage = () => {
   }, []);
 
   const handleApprove = async (requestId) => {
+    const request = requests.find((item) => item.id === requestId);
+
+    if (!request) {
+      setMessage("הבקשה לא נמצאה.");
+      return;
+    }
+
     setActionLoadingId(requestId);
     setMessage("");
 
     try {
-      await privacyService.approvePrivacyRequest(requestId, currentUser);
+      await privacyService.approvePrivacyRequest(request, currentUser);
       setMessage("הבקשה אושרה בהצלחה.");
       await loadRequests();
     } catch (error) {
@@ -62,11 +69,18 @@ const PrivacyRequestsPage = () => {
   };
 
   const handleReject = async (requestId) => {
+    const request = requests.find((item) => item.id === requestId);
+
+    if (!request) {
+      setMessage("הבקשה לא נמצאה.");
+      return;
+    }
+
     setActionLoadingId(requestId);
     setMessage("");
 
     try {
-      await privacyService.rejectPrivacyRequest(requestId, currentUser);
+      await privacyService.rejectPrivacyRequest(request, currentUser);
       setMessage("הבקשה נדחתה בהצלחה.");
       await loadRequests();
     } catch (error) {
@@ -219,9 +233,11 @@ const PrivacyRequestsPage = () => {
                     borderRadius: "999px",
                     background: "#0f7b35",
                     color: "white",
-                    cursor: "pointer",
+                    cursor:
+                      actionLoadingId === request.id ? "not-allowed" : "pointer",
                     fontWeight: "bold",
                     fontFamily: "inherit",
+                    opacity: actionLoadingId === request.id ? 0.7 : 1,
                   }}
                 >
                   {actionLoadingId === request.id ? "מאשר..." : "אשר"}
@@ -236,9 +252,11 @@ const PrivacyRequestsPage = () => {
                     borderRadius: "999px",
                     background: "#b00020",
                     color: "white",
-                    cursor: "pointer",
+                    cursor:
+                      actionLoadingId === request.id ? "not-allowed" : "pointer",
                     fontWeight: "bold",
                     fontFamily: "inherit",
+                    opacity: actionLoadingId === request.id ? 0.7 : 1,
                   }}
                 >
                   {actionLoadingId === request.id ? "דוחה..." : "דחה"}

--- a/frontend/src/services/interfaces/privacy-service.js
+++ b/frontend/src/services/interfaces/privacy-service.js
@@ -4,8 +4,11 @@ import {
   query,
   where,
   getDocs,
+  getDoc,
   doc,
   updateDoc,
+  setDoc,
+  arrayUnion,
   serverTimestamp,
 } from "firebase/firestore";
 
@@ -127,6 +130,42 @@ export const privacyService = {
   },
 
   /**
+   * Fetches private contact details for an employer.
+   * Firestore Rules decide whether the current user is allowed to read it.
+   *
+   * @param {Object} currentUser - Current logged-in user.
+   * @param {Object} targetEmployer - Employer profile.
+   * @returns {Promise<Object|null>} Private contact details or null.
+   */
+  async getPrivateContactDetails(currentUser, targetEmployer) {
+    if (!currentUser?.email || !targetEmployer?.email) {
+      return null;
+    }
+
+    const privateInfoRef = doc(
+      db,
+      "users",
+      targetEmployer.email,
+      "private_info",
+      "details"
+    );
+
+    const privateInfoSnap = await getDoc(privateInfoRef);
+
+    if (!privateInfoSnap.exists()) {
+      return null;
+    }
+
+    const data = privateInfoSnap.data();
+
+    return {
+      phone: data.phone || "",
+      directEmail: data.directEmail || "",
+      approvedViewers: data.approved_viewers || [],
+    };
+  },
+
+  /**
    * Fetches all pending privacy requests.
    * This is intended for admin review.
    *
@@ -158,21 +197,39 @@ export const privacyService = {
 
   /**
    * Approves a pending privacy request.
+   * In addition to changing the request status, the requester is added
+   * to the target employer's approved_viewers list.
    *
-   * @param {string} requestId - Firestore document id.
+   * @param {Object} request - Privacy request object.
    * @param {Object} currentUser - Current logged-in admin/employer user.
    * @returns {Promise<Object>} Result.
    */
-  async approvePrivacyRequest(requestId, currentUser) {
-    if (!requestId) {
+  async approvePrivacyRequest(request, currentUser) {
+    if (!request?.id) {
       throw new Error("Request id is missing.");
+    }
+
+    if (!request?.requesterEmail) {
+      throw new Error("Requester email is missing.");
+    }
+
+    if (!request?.targetEmail) {
+      throw new Error("Target employer email is missing.");
     }
 
     if (!currentUser?.email) {
       throw new Error("User must be logged in to approve a request.");
     }
 
-    const requestRef = doc(db, "privacy_requests", requestId);
+    const requestRef = doc(db, "privacy_requests", request.id);
+
+    const privateInfoRef = doc(
+      db,
+      "users",
+      request.targetEmail,
+      "private_info",
+      "details"
+    );
 
     await updateDoc(requestRef, {
       status: "approved",
@@ -180,6 +237,15 @@ export const privacyService = {
       reviewedBy: currentUser.email,
       updatedAt: serverTimestamp(),
     });
+
+    await setDoc(
+      privateInfoRef,
+      {
+        approved_viewers: arrayUnion(request.requesterEmail),
+        updatedAt: serverTimestamp(),
+      },
+      { merge: true }
+    );
 
     return {
       status: "approved",
@@ -190,12 +256,12 @@ export const privacyService = {
   /**
    * Rejects a pending privacy request.
    *
-   * @param {string} requestId - Firestore document id.
+   * @param {Object} request - Privacy request object.
    * @param {Object} currentUser - Current logged-in admin/employer user.
    * @returns {Promise<Object>} Result.
    */
-  async rejectPrivacyRequest(requestId, currentUser) {
-    if (!requestId) {
+  async rejectPrivacyRequest(request, currentUser) {
+    if (!request?.id) {
       throw new Error("Request id is missing.");
     }
 
@@ -203,7 +269,7 @@ export const privacyService = {
       throw new Error("User must be logged in to reject a request.");
     }
 
-    const requestRef = doc(db, "privacy_requests", requestId);
+    const requestRef = doc(db, "privacy_requests", request.id);
 
     await updateDoc(requestRef, {
       status: "rejected",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "cheerio": "^1.0.0-rc.12",
         "dotenv": "^17.4.2",
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^4.5.0"
+        "firebase-functions": "^4.5.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/node": "^25.7.0",
@@ -3971,6 +3972,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4526,6 +4536,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4667,6 +4690,15 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -4822,6 +4854,18 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-require": {
@@ -6100,6 +6144,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -9769,6 +9822,18 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -10678,6 +10743,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10745,6 +10828,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-naming": {


### PR DESCRIPTION
## Summary

Completes the UC4 private contact details flow.

## Implemented

- Added Excel-to-JSON conversion script for employer import data
- Updated employer import script to create `private_info/details`
- Stored private contact details separately from public directory data
- Added `approved_viewers` support for approved coordinators
- Updated approval flow to add approved coordinators to employer private details
- Updated employer profile page to show private contact details only to authorized users

## Notes

- Real Excel and JSON data files are not committed to GitHub.
- Private customer/employer data remains local and excluded by `.gitignore`.